### PR TITLE
Use 24-hour format for German translations

### DIFF
--- a/lib/translations/de_DE.js
+++ b/lib/translations/de_DE.js
@@ -14,5 +14,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
 });
 
 jQuery.extend( jQuery.fn.pickatime.defaults, {
-    clear: 'Löschen'
+    clear: 'Löschen',
+    format: 'H:i'
 });


### PR DESCRIPTION
As a native German speaker I can confirm that in all German speaking regions (Germany, Austria, Swiss and Lichtenstein) the 24-hour format is used.
